### PR TITLE
Added country and US state codes

### DIFF
--- a/chemSpellCheck.css
+++ b/chemSpellCheck.css
@@ -2,7 +2,7 @@
     background: plum;
     padding: 1rem;
     border-radius: 1rem;
-    height: 44.5rem;
+    height: 48rem;
     width: 52rem;
 }
 
@@ -43,7 +43,7 @@ div {
     border: solid;
     /*padding: 2rem;*/
     width: 50rem;
-    height: 30rem;
+    height: 25rem;
     display: flex;
 
 }

--- a/chemSpellCheck.js
+++ b/chemSpellCheck.js
@@ -1,6 +1,6 @@
-let outputStyle = 0;
-let outputText = "";
-const twoLetterIndex = 14;
+let outputStyle = 0; // 0 = symbols, 1 = full names
+let outputText = ""; // a global variable used to hold the output text
+
 const elements = [
     ["B", "Boron"],
     ["C", "Carbon"],
@@ -121,6 +121,313 @@ const elements = [
     ["Zn", "Zinc"],
     ["Zr", "Zirconium"]
 ];
+const countries = [ // ISO 3166-1 alpha-2
+    ["AD", "Andorra"],
+    ["AE", "United Arab Emirates"],
+    ["AF", "Afghanistan"],
+    ["AG", "Antigua and Barbuda"],
+    ["AI", "Anguilla"],
+    ["AL", "Albania"],
+    ["AM", "Armenia"],
+    ["AO", "Angola"],
+    ["AQ", "Antarctica"],
+    ["AR", "Argentina"],
+    ["AS", "American Samoa"],
+    ["AT", "Austria"],
+    ["AU", "Australia"],
+    ["AW", "Aruba"],
+    ["AX", "Åland Islands"],
+    ["AZ", "Azerbaijan"],
+    ["BA", "Bosnia and Herzegovina"],
+    ["BB", "Barbados"],
+    ["BD", "Bangladesh"],
+    ["BE", "Belgium"],
+    ["BF", "Burkina Faso"],
+    ["BG", "Bulgaria"],
+    ["BH", "Bahrain"],
+    ["BI", "Burundi"],
+    ["BJ", "Benin"],
+    ["BL", "Saint Barthélemy"],
+    ["BM", "Bermuda"],
+    ["BN", "Brunei Darussalam"],
+    ["BO", "Bolivia (Plurinational State of)"],
+    ["BQ", "Bonaire, Sint Eustatius and Saba"],
+    ["BR", "Brazil"],
+    ["BS", "Bahamas"],
+    ["BT", "Bhutan"],
+    ["BV", "Bouvet Island"],
+    ["BW", "Botswana"],
+    ["BY", "Belarus"],
+    ["BZ", "Belize"],
+    ["CA", "Canada"],
+    ["CC", "Cocos (Keeling) Islands"],
+    ["CD", "Congo, Democratic Republic of the"],
+    ["CF", "Central African Republic"],
+    ["CG", "Congo"],
+    ["CH", "Switzerland"],
+    ["CI", "Côte d'Ivoire"],
+    ["CK", "Cook Islands"],
+    ["CL", "Chile"],
+    ["CM", "Cameroon"],
+    ["CN", "China"],
+    ["CO", "Colombia"],
+    ["CR", "Costa Rica"],
+    ["CU", "Cuba"],
+    ["CV", "Cabo Verde"],
+    ["CW", "Curaçao"],
+    ["CX", "Christmas Island"],
+    ["CY", "Cyprus"],
+    ["CZ", "Czechia"],
+    ["DE", "Germany"],
+    ["DJ", "Djibouti"],
+    ["DK", "Denmark"],
+    ["DM", "Dominica"],
+    ["DO", "Dominican Republic"],
+    ["DZ", "Algeria"],
+    ["EC", "Ecuador"],
+    ["EE", "Estonia"],
+    ["EG", "Egypt"],
+    ["EH", "Western Sahara"],
+    ["ER", "Eritrea"],
+    ["ES", "Spain"],
+    ["ET", "Ethiopia"],
+    ["FI", "Finland"],
+    ["FJ", "Fiji"],
+    ["FK", "Falkland Islands (Malvinas)"],
+    ["FM", "Micronesia (Federated States of)"],
+    ["FO", "Faroe Islands"],
+    ["FR", "France"],
+    ["GA", "Gabon"],
+    ["GB", "United Kingdom of Great Britain and Northern Ireland"],
+    ["GD", "Grenada"],
+    ["GE", "Georgia"],
+    ["GF", "French Guiana"],
+    ["GG", "Guernsey"],
+    ["GH", "Ghana"],
+    ["GI", "Gibraltar"],
+    ["GL", "Greenland"],
+    ["GM", "Gambia"],
+    ["GN", "Guinea"],
+    ["GP", "Guadeloupe"],
+    ["GQ", "Equatorial Guinea"],
+    ["GR", "Greece"],
+    ["GS", "South Georgia and the South Sandwich Islands"],
+    ["GT", "Guatemala"],
+    ["GU", "Guam"],
+    ["GW", "Guinea-Bissau"],
+    ["GY", "Guyana"],
+    ["HK", "Hong Kong"],
+    ["HM", "Heard Island and McDonald Islands"],
+    ["HN", "Honduras"],
+    ["HR", "Croatia"],
+    ["HT", "Haiti"],
+    ["HU", "Hungary"],
+    ["ID", "Indonesia"],
+    ["IE", "Ireland"],
+    ["IL", "Israel"],
+    ["IM", "Isle of Man"],
+    ["IN", "India"],
+    ["IO", "British Indian Ocean Territory"],
+    ["IQ", "Iraq"],
+    ["IR", "Iran (Islamic Republic of)"],
+    ["IS", "Iceland"],
+    ["IT", "Italy"],
+    ["JE", "Jersey"],
+    ["JM", "Jamaica"],
+    ["JO", "Jordan"],
+    ["JP", "Japan"],
+    ["KE", "Kenya"],
+    ["KG", "Kyrgyzstan"],
+    ["KH", "Cambodia"],
+    ["KI", "Kiribati"],
+    ["KM", "Comoros"],
+    ["KN", "Saint Kitts and Nevis"],
+    ["KP", "Korea (Democratic People's Republic of)"],
+    ["KR", "Korea, Republic of"],
+    ["KW", "Kuwait"],
+    ["KY", "Cayman Islands"],
+    ["KZ", "Kazakhstan"],
+    ["LA", "Lao People's Democratic Republic"],
+    ["LB", "Lebanon"],
+    ["LC", "Saint Lucia"],
+    ["LI", "Liechtenstein"],
+    ["LK", "Sri Lanka"],
+    ["LR", "Liberia"],
+    ["LS", "Lesotho"],
+    ["LT", "Lithuania"],
+    ["LU", "Luxembourg"],
+    ["LV", "Latvia"],
+    ["LY", "Libya"],
+    ["MA", "Morocco"],
+    ["MC", "Monaco"],
+    ["MD", "Moldova, Republic of"],
+    ["ME", "Montenegro"],
+    ["MF", "Saint Martin (French part)"],
+    ["MG", "Madagascar"],
+    ["MH", "Marshall Islands"],
+    ["MK", "North Macedonia"],
+    ["ML", "Mali"],
+    ["MM", "Myanmar"],
+    ["MN", "Mongolia"],
+    ["MO", "Macao"],
+    ["MP", "Northern Mariana Islands"],
+    ["MQ", "Martinique"],
+    ["MR", "Mauritania"],
+    ["MS", "Montserrat"],
+    ["MT", "Malta"],
+    ["MU", "Mauritius"],
+    ["MV", "Maldives"],
+    ["MW", "Malawi"],
+    ["MX", "Mexico"],
+    ["MY", "Malaysia"],
+    ["MZ", "Mozambique"],
+    ["NA", "Namibia"],
+    ["NC", "New Caledonia"],
+    ["NE", "Niger"],
+    ["NF", "Norfolk Island"],
+    ["NG", "Nigeria"],
+    ["NI", "Nicaragua"],
+    ["NL", "Netherlands"],
+    ["NO", "Norway"],
+    ["NP", "Nepal"],
+    ["NR", "Nauru"],
+    ["NU", "Niue"],
+    ["NZ", "New Zealand"],
+    ["OM", "Oman"],
+    ["PA", "Panama"],
+    ["PE", "Peru"],
+    ["PF", "French Polynesia"],
+    ["PG", "Papua New Guinea"],
+    ["PH", "Philippines"],
+    ["PK", "Pakistan"],
+    ["PL", "Poland"],
+    ["PM", "Saint Pierre and Miquelon"],
+    ["PN", "Pitcairn"],
+    ["PR", "Puerto Rico"],
+    ["PS", "Palestine, State of"],
+    ["PT", "Portugal"],
+    ["PW", "Palau"],
+    ["PY", "Paraguay"],
+    ["QA", "Qatar"],
+    ["RE", "Réunion"],
+    ["RO", "Romania"],
+    ["RS", "Serbia"],
+    ["RU", "Russian Federation"],
+    ["RW", "Rwanda"],
+    ["SA", "Saudi Arabia"],
+    ["SB", "Solomon Islands"],
+    ["SC", "Seychelles"],
+    ["SD", "Sudan"],
+    ["SE", "Sweden"],
+    ["SG", "Singapore"],
+    ["SH", "Saint Helena, Ascension and Tristan da Cunha"],
+    ["SI", "Slovenia"],
+    ["SJ", "Svalbard and Jan Mayen"],
+    ["SK", "Slovakia"],
+    ["SL", "Sierra Leone"],
+    ["SM", "San Marino"],
+    ["SN", "Senegal"],
+    ["SO", "Somalia"],
+    ["SR", "Suriname"],
+    ["SS", "South Sudan"],
+    ["ST", "Sao Tome and Principe"],
+    ["SV", "El Salvador"],
+    ["SX", "Sint Maarten (Dutch part)"],
+    ["SY", "Syrian Arab Republic"],
+    ["SZ", "Eswatini"],
+    ["TC", "Turks and Caicos Islands"],
+    ["TD", "Chad"],
+    ["TF", "French Southern Territories"],
+    ["TG", "Togo"],
+    ["TH", "Thailand"],
+    ["TJ", "Tajikistan"],
+    ["TK", "Tokelau"],
+    ["TL", "Timor-Leste"],
+    ["TM", "Turkmenistan"],
+    ["TN", "Tunisia"],
+    ["TO", "Tonga"],
+    ["TR", "Turkey"],
+    ["TT", "Trinidad and Tobago"],
+    ["TV", "Tuvalu"],
+    ["TW", "Taiwan, Province of China"],
+    ["TZ", "Tanzania, United Republic of"],
+    ["UA", "Ukraine"],
+    ["UG", "Uganda"],
+    ["UM", "United States Minor Outlying Islands"],
+    ["US", "United States of America"],
+    ["UY", "Uruguay"],
+    ["UZ", "Uzbekistan"],
+    ["VA", "Holy See"],
+    ["VC", "Saint Vincent and the Grenadines"],
+    ["VE", "Venezuela (Bolivarian Republic of)"],
+    ["VG", "Virgin Islands (British)"],
+    ["VI", "Virgin Islands (U.S.)"],
+    ["VN", "Viet Nam"],
+    ["VU", "Vanuatu"],
+    ["WF", "Wallis and Futuna"],
+    ["WS", "Samoa"],
+    ["YE", "Yemen"],
+    ["YT", "Mayotte"],
+    ["ZA", "South Africa"],
+    ["ZM", "Zambia"],
+    ["ZW", "Zimbabwe"]
+];
+
+const states = [
+    ["AL", "Alabama"],
+    ["AK", "Alaska"],
+    ["AZ", "Arizona"],
+    ["AR", "Arkansas"],
+    ["CA", "California"],
+    ["CO", "Colorado"],
+    ["CT", "Connecticut"],
+    ["DE", "Delaware"],
+    ["DC", "District of Columbia"],
+    ["FL", "Florida"],
+    ["GA", "Georgia"],
+    ["HI", "Hawaii"],
+    ["ID", "Idaho"],
+    ["IL", "Illinois"],
+    ["IN", "Indiana"],
+    ["IA", "Iowa"],
+    ["KS", "Kansas"],
+    ["KY", "Kentucky"],
+    ["LA", "Louisiana"],
+    ["ME", "Maine"],
+    ["MD", "Maryland"],
+    ["MA", "Massachusetts"],
+    ["MI", "Michigan"],
+    ["MN", "Minnesota"],
+    ["MS", "Mississippi"],
+    ["MO", "Missouri"],
+    ["MT", "Montana"],
+    ["NE", "Nebraska"],
+    ["NV", "Nevada"],
+    ["NH", "New Hampshire"],
+    ["NJ", "New Jersey"],
+    ["NM", "New Mexico"],
+    ["NY", "New York"],
+    ["NC", "North Carolina"],
+    ["ND", "North Dakota"],
+    ["OH", "Ohio"],
+    ["OK", "Oklahoma"],
+    ["OR", "Oregon"],
+    ["PA", "Pennsylvania"],
+    ["RI", "Rhode Island"],
+    ["SC", "South Carolina"],
+    ["SD", "South Dakota"],
+    ["TN", "Tennessee"],
+    ["TX", "Texas"],
+    ["UT", "Utah"],
+    ["VT", "Vermont"],
+    ["VA", "Virginia"],
+    ["WA", "Washington"],
+    ["WV", "West Virginia"],
+    ["WI", "Wisconsin"],
+    ["WY", "Wyoming"]
+];
+
+let selectedList = elements;
 
 function checkNextLetters(inputString, indicesSoFar, originalWord) {
     // If the word is done, that means you have a viable ChemSpell. Write it out.
@@ -132,30 +439,19 @@ function checkNextLetters(inputString, indicesSoFar, originalWord) {
 
     // Could probably combine these two checks into one.
 
-    // If the word has at least two letters left, check them for any matches with the two-letter symbols.
-    if (inputString.length >= 2) {
-        for (let i = twoLetterIndex; i < elements.length; i++) {
-            if (inputString.substr(0, 2).toLowerCase() === elements[i][0].toLowerCase()) {
-                checkNextLetters(inputString.slice(2), indicesSoFar.concat(i), originalWord)
-            }
+    for (let i = 0; i < selectedList.length; i++) {
+        let symbolLength = selectedList[i][0].length;
+        if (inputString.substr(0, symbolLength).toLowerCase() === selectedList[i][0].toLowerCase()) {
+            checkNextLetters(inputString.slice(symbolLength), indicesSoFar.concat(i), originalWord);
         }
     }
-
-    // Lastly, check the first letter of the word for any matches with the one-letter symbols.
-    for (let i = 0; i < twoLetterIndex; i++) {
-        if (inputString.substr(0, 1).toLowerCase() === elements[i][0].toLowerCase()) {
-            checkNextLetters(inputString.slice(1), indicesSoFar.concat(i), originalWord)
-        }
-    }
-
-
     return;
 }
 
 function writeOutput(indices, originalWord) {
     outputLine = "";
     indices.forEach((index) => {
-        outputLine += elements[index][outputStyle] + " - ";
+        outputLine += selectedList[index][outputStyle] + " - ";
     });
     outputText += (originalWord + ": " + outputLine.slice(0, -3) + "\n");
 }
@@ -171,28 +467,36 @@ function checkClick() {
         outputStyle = 0;
     }
 
-    var inputElement = document.getElementById("inputtext");
-    var inputs = inputElement.value.split('\n');
+    if (document.getElementById("elementList").checked) {
+        selectedList = elements;
+    } else if (document.getElementById("countryList").checked) {
+        selectedList = countries;
+    } else {
+        selectedList = states;
+    }
+
+    var inputTextElement = document.getElementById("inputtext");
+    var inputs = inputTextElement.value.split('\n');
     inputs.forEach((input) => {
         if (input.replace(/[^a-zA-Z]/g, "").length > 0) {
             checkNextLetters(input.replace(/[^a-zA-Z]/g, ""), new Array(), input)
         }
-        var outputElement = document.getElementById("outputtext");
-        outputElement.value = outputText;
+        var outputTextElement = document.getElementById("outputtext");
+        outputTextElement.value = outputText;
     });
 }
 
 function sortAlpha() { // Taken from StackOverflow: https://stackoverflow.com/questions/8996963/how-to-perform-case-insensitive-sorting-array-of-string-in-javascript
     var listToSort = document.getElementById("inputtext").value.split('\n');
-    listToSort = listToSort.sort((a, b) => a.localeCompare(b, undefined, {sensitivity: 'base'}));
+    listToSort = listToSort.sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' }));
     document.getElementById("inputtext").value = listToSort.join('\n');
 }
 
-function sortLength() {// Taken from StackOverflow: https://stackoverflow.com/questions/10630766/how-to-sort-an-array-based-on-the-length-of-each-element/10630852
-	var listToSort = document.getElementById("inputtext").value.split('\n');
-	listToSort = listToSort.sort(function(a, b) {
-  return a.length - b.length || // sort by length, if equal then
-         a.localeCompare(b, undefined, {sensitivity: 'base'});    // sort by dictionary order
-});
-	document.getElementById("inputtext").value = listToSort.join('\n');
+function sortLength() { // Taken from StackOverflow: https://stackoverflow.com/questions/10630766/how-to-sort-an-array-based-on-the-length-of-each-element/10630852
+    var listToSort = document.getElementById("inputtext").value.split('\n');
+    listToSort = listToSort.sort(function(a, b) {
+        return a.length - b.length || // sort by length, if equal then
+            a.localeCompare(b, undefined, { sensitivity: 'base' }); // sort by dictionary order
+    });
+    document.getElementById("inputtext").value = listToSort.join('\n');
 }

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
     <title>qrayx's ChemSpell Checker</title>
     <link rel="stylesheet" type="text/css" href="chemSpellCheck.css" />
     <script src="chemSpellCheck.js"></script>
+    <meta charset="utf-8">
 </head>
 
 <body>
@@ -21,19 +22,11 @@
                 <div id="input">
                     <label for="inputform" class="title"><strong>Input</strong></label>
                     <form id="inputform">
-                        <textarea id="inputtext" name="inputtext">Cinnamon
-Hot Latte
-Clara's Orange</textarea>
+                        <textarea id="inputtext" name="inputtext">
+Clara's Orange
+Calamari
+Cabidela</textarea>
                     </form>
-                    <label class="title">Output Style</label>
-                    <label for="symbolradio" class="radiolabel">Symbols</label>
-                    <input id="symbolradio" type="radio" name="outputtype" checked="checked">
-                    <label for="fullnameradio" class="radiolabel">Full Names</label>
-                    <input id="fullnameradio" type="radio" name="outputtype">
-                    <br>
-                    <input type="submit" value="Check" onclick="checkClick()">
-                    <input type="submit" value="Sort A-Z" onclick="sortAlpha()">
-                    <input type="submit" value="Sort Length" onclick="sortLength()">
                 </div>
                 <div id="output">
                     <label for="outputform" class="title"><strong>Results</strong></label>
@@ -43,6 +36,26 @@ Clara's Orange</textarea>
                         <textarea id="outputtext" name="outputtext" readonly></textarea>
                     </form>
                 </div>
+            </div>
+            <div id="controlPanel">
+                <label class="title">Output Style</label>
+                <label for="symbolradio" class="radiolabel">Symbols</label>
+                <input id="symbolradio" type="radio" name="outputtype" checked="checked">
+                <label for="fullnameradio" class="radiolabel">Full Names</label>
+                <input id="fullnameradio" type="radio" name="outputtype">
+                <br>
+                <br>
+                <label for="elementList" class="radiolabel">Elements</label>
+                <input id="elementList" type="radio" name="litsToUse" checked="checked">
+                <label for="countryList" class="radiolabel">Countries</label>
+                <input id="countryList" type="radio" name="litsToUse">
+                <label for="stateList" class="radiolabel">United States</label>
+                <input id="stateList" type="radio" name="litsToUse">
+                <br>
+                <br>
+                <input type="submit" value="Check" onclick="checkClick()">
+                <input type="submit" value="Sort A-Z" onclick="sortAlpha()">
+                <input type="submit" value="Sort Length" onclick="sortLength()">
             </div>
         </section>
         <div>


### PR DESCRIPTION
Simplified the check. Now, instead of checking the single-letter symbols and the double-letter symbols separately, it looks at the length of the symbol in a single loop.

Also, I added two new lists of symbols: ISO 3166 country codes, and US two-letter state codes.

I updated the examples to show these new lists.

I moved the control panel around because I added new radio buttons to select the new lists.